### PR TITLE
Fix Java 11 Test Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.project
 /.settings/
 /target/
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -124,11 +124,6 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<artifactId>kotlin-scripting-jsr223</artifactId>
 			<version>${kotlin.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-scripting-jvm-host</artifactId>
-			<version>${kotlin.version}</version>
-		</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 			</activation>
 			<properties>
 				<kotlin-compiler-embeddable.optional>true</kotlin-compiler-embeddable.optional>
+				<scijava.ignoreOptionalDependencies>true</scijava.ignoreOptionalDependencies>
 			</properties>
 			<build>
 				<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-script-util</artifactId>
+			<artifactId>kotlin-scripting-jvm-host</artifactId>
 			<version>${kotlin.version}</version>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
 
 		<kotlin-compiler-embeddable.optional>false</kotlin-compiler-embeddable.optional>
+		<scijava-maven-plugin.version>2.1.0</scijava-maven-plugin.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,14 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<!-- NB: Work around duplicate classes issue in Kotlin dependencies-->
 		<allowedDuplicateClasses>org/jetbrains/kotlin/daemon/common/*,kotlinx/coroutines/**</allowedDuplicateClasses>
 		<kotlin.version>1.4.30</kotlin.version>
-		<!-- NB: Have to disable manifest-only jar ot be able to run tests on command line. -->
+		<!-- NB: We have to disable manifest-only jar ot be able to run tests on command line. -->
 		<!-- NB: Tests work in IntelliJ but manifest-only jar seems to mess with it on command line. -->
 		<!-- NB: cf: mvn surefire:help -Ddetail=true -->
 		<surefire.useManifestOnlyJar>false</surefire.useManifestOnlyJar>
+
+		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+
+		<kotlin-compiler-embeddable.optional>false</kotlin-compiler-embeddable.optional>
 	</properties>
 
 	<repositories>
@@ -113,6 +117,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-compiler-embeddable</artifactId>
 			<version>${kotlin.version}</version>
+			<optional>${kotlin-compiler-embeddable.optional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
@@ -138,4 +143,54 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<!-- The JetBrains trove4j fork clashes with the gnu trove4j jar in Fiji.
+			     We need to shade and relocate in this case. -->
+			<id>shade-trove4j-fork</id>
+			<activation>
+				<property>
+					<name>scijava.app.directory</name>
+				</property>
+			</activation>
+			<properties>
+				<kotlin-compiler-embeddable.optional>true</kotlin-compiler-embeddable.optional>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>${maven-shade-plugin.version}</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<artifactSet>
+										<includes>
+											<include>org.jetbrains.intellij.deps:trove4j</include>
+											<include>org.jetbrains.kotlin:kotlin-compiler-embeddable</include>
+											<include>org.jetbrains.kotlin:kotlin-script-runtime</include>
+											<include>org.jetbrains.kotlin:kotlin-reflect</include>
+											<include>org.jetbrains.kotlin:kotlin-daemon-embeddable</include>
+										</includes>
+									</artifactSet>
+									<relocations>
+										<relocation>
+											<pattern>gnu.trove</pattern>
+											<shadedPattern>gnu.trove.shaded</shadedPattern>
+										</relocation>
+									</relocations>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<artifactId>kotlin-scripting-jsr223</artifactId>
 			<version>${kotlin.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-script-util</artifactId>
+			<version>${kotlin.version}</version>
+		</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>

--- a/src/main/kotlin/org/scijava/plugins/scripting/kotlin/KotlinScriptLanguage.kt
+++ b/src/main/kotlin/org/scijava/plugins/scripting/kotlin/KotlinScriptLanguage.kt
@@ -53,38 +53,7 @@ class KotlinScriptLanguage : AdaptedScriptLanguage(Factory()) {
     override fun getExtensions() = listOf("kt", "kts")
 
     class Factory : KotlinJsr223JvmScriptEngineFactoryBase() {
-        override fun getScriptEngine(): ScriptEngine {
-            return SynchronizedScriptEngine(
-//                KotlinJsr223JvmDaemonCompileScriptEngine(
-//                    this,
-//                    KotlinJars.compilerWithScriptingClasspath,
-//                    scriptCompilationClasspathFromContext("kotlin-script-util.jar", wholeClasspath = true),
-//                    KotlinStandardJsr223ScriptTemplate::class.qualifiedName!!,
-//                    { ctx, types -> ScriptArgsWithTypes(arrayOf(ctx.getBindings(ScriptContext.ENGINE_SCOPE)), types ?: emptyArray()) },
-//                    arrayOf(Bindings::class)
-//                )
-//                KotlinJsr223JvmLocalScriptEngine(
-//                    this,
-//                    scriptCompilationClasspathFromContext("kotlin-script-util.jar", wholeClasspath = true),
-//                    KotlinStandardJsr223ScriptTemplate::class.qualifiedName!!,
-//                    { ctx, types -> ScriptArgsWithTypes(arrayOf(ctx.getBindings(ScriptContext.ENGINE_SCOPE)), types ?: emptyArray()) },
-//                    arrayOf(Bindings::class))
-//                KotlinJsr223ScriptEngineImpl(
-//                    this,
-//                    scriptDefinition.compilationConfiguration.with {
-//                        jvm {
-//                            if (System.getProperty(KOTLIN_JSR223_RESOLVE_FROM_CLASSLOADER_PROPERTY) == "true") {
-//                                dependencies(JvmDependencyFromClassLoader { Thread.currentThread().contextClassLoader })
-//                            } else {
-//                                dependenciesFromCurrentContext()
-//                            }
-//                        }
-//                    },
-//                    scriptDefinition.evaluationConfiguration
-//                ) { ScriptArgsWithTypes(arrayOf(it.getBindings(ScriptContext.ENGINE_SCOPE).orEmpty()), arrayOf(Bindings::class)) }
-                KotlinJsr223DefaultScriptEngineFactory().scriptEngine
-            )
-        }
+        override fun getScriptEngine() = SynchronizedScriptEngine(KotlinJsr223DefaultScriptEngineFactory().scriptEngine)
     }
 
     class SynchronizedScriptEngine(private val delegate: ScriptEngine) : ScriptEngine {

--- a/src/main/kotlin/org/scijava/plugins/scripting/kotlin/KotlinScriptLanguage.kt
+++ b/src/main/kotlin/org/scijava/plugins/scripting/kotlin/KotlinScriptLanguage.kt
@@ -29,22 +29,13 @@
  */
 package org.scijava.plugins.scripting.kotlin
 
-import org.jetbrains.kotlin.cli.common.repl.*
-import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmDaemonCompileScriptEngine
-import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngine
-import org.jetbrains.kotlin.script.jsr223.KotlinStandardJsr223ScriptTemplate
+import org.jetbrains.kotlin.cli.common.repl.KotlinJsr223JvmScriptEngineFactoryBase
 import org.scijava.plugin.Plugin
 import org.scijava.script.AdaptedScriptLanguage
 import org.scijava.script.ScriptLanguage
 import java.io.Reader
-import java.lang.Exception
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.locks.ReentrantReadWriteLock
 import javax.script.*
-import kotlin.script.experimental.jvm.util.KotlinJars
-import kotlin.script.experimental.jvm.util.scriptCompilationClasspathFromContext
-import kotlin.system.exitProcess
+import kotlin.script.experimental.jsr223.KotlinJsr223DefaultScriptEngineFactory
 
 /**
  * A SciJava [ScriptLanguage] for Kotlin.
@@ -72,12 +63,26 @@ class KotlinScriptLanguage : AdaptedScriptLanguage(Factory()) {
 //                    { ctx, types -> ScriptArgsWithTypes(arrayOf(ctx.getBindings(ScriptContext.ENGINE_SCOPE)), types ?: emptyArray()) },
 //                    arrayOf(Bindings::class)
 //                )
-                KotlinJsr223JvmLocalScriptEngine(
-                    this,
-                    scriptCompilationClasspathFromContext("kotlin-script-util.jar", wholeClasspath = true),
-                    KotlinStandardJsr223ScriptTemplate::class.qualifiedName!!,
-                    { ctx, types -> ScriptArgsWithTypes(arrayOf(ctx.getBindings(ScriptContext.ENGINE_SCOPE)), types ?: emptyArray()) },
-                    arrayOf(Bindings::class))
+//                KotlinJsr223JvmLocalScriptEngine(
+//                    this,
+//                    scriptCompilationClasspathFromContext("kotlin-script-util.jar", wholeClasspath = true),
+//                    KotlinStandardJsr223ScriptTemplate::class.qualifiedName!!,
+//                    { ctx, types -> ScriptArgsWithTypes(arrayOf(ctx.getBindings(ScriptContext.ENGINE_SCOPE)), types ?: emptyArray()) },
+//                    arrayOf(Bindings::class))
+//                KotlinJsr223ScriptEngineImpl(
+//                    this,
+//                    scriptDefinition.compilationConfiguration.with {
+//                        jvm {
+//                            if (System.getProperty(KOTLIN_JSR223_RESOLVE_FROM_CLASSLOADER_PROPERTY) == "true") {
+//                                dependencies(JvmDependencyFromClassLoader { Thread.currentThread().contextClassLoader })
+//                            } else {
+//                                dependenciesFromCurrentContext()
+//                            }
+//                        }
+//                    },
+//                    scriptDefinition.evaluationConfiguration
+//                ) { ScriptArgsWithTypes(arrayOf(it.getBindings(ScriptContext.ENGINE_SCOPE).orEmpty()), arrayOf(Bindings::class)) }
+                KotlinJsr223DefaultScriptEngineFactory().scriptEngine
             )
         }
     }

--- a/src/main/kotlin/org/scijava/plugins/scripting/kotlin/KotlinScriptLanguage.kt
+++ b/src/main/kotlin/org/scijava/plugins/scripting/kotlin/KotlinScriptLanguage.kt
@@ -29,12 +29,22 @@
  */
 package org.scijava.plugins.scripting.kotlin
 
-import org.jetbrains.kotlin.cli.common.repl.KotlinJsr223JvmScriptEngineFactoryBase
+import org.jetbrains.kotlin.cli.common.repl.*
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmDaemonCompileScriptEngine
+import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngine
+import org.jetbrains.kotlin.script.jsr223.KotlinStandardJsr223ScriptTemplate
 import org.scijava.plugin.Plugin
 import org.scijava.script.AdaptedScriptLanguage
 import org.scijava.script.ScriptLanguage
 import java.io.Reader
+import java.lang.Exception
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import javax.script.*
+import kotlin.script.experimental.jvm.util.KotlinJars
+import kotlin.script.experimental.jvm.util.scriptCompilationClasspathFromContext
+import kotlin.system.exitProcess
 
 /**
  * A SciJava [ScriptLanguage] for Kotlin.
@@ -53,7 +63,22 @@ class KotlinScriptLanguage : AdaptedScriptLanguage(Factory()) {
 
     class Factory : KotlinJsr223JvmScriptEngineFactoryBase() {
         override fun getScriptEngine(): ScriptEngine {
-            return SynchronizedScriptEngine(ScriptEngineManager().getEngineByExtension("kts"))
+            return SynchronizedScriptEngine(
+//                KotlinJsr223JvmDaemonCompileScriptEngine(
+//                    this,
+//                    KotlinJars.compilerWithScriptingClasspath,
+//                    scriptCompilationClasspathFromContext("kotlin-script-util.jar", wholeClasspath = true),
+//                    KotlinStandardJsr223ScriptTemplate::class.qualifiedName!!,
+//                    { ctx, types -> ScriptArgsWithTypes(arrayOf(ctx.getBindings(ScriptContext.ENGINE_SCOPE)), types ?: emptyArray()) },
+//                    arrayOf(Bindings::class)
+//                )
+                KotlinJsr223JvmLocalScriptEngine(
+                    this,
+                    scriptCompilationClasspathFromContext("kotlin-script-util.jar", wholeClasspath = true),
+                    KotlinStandardJsr223ScriptTemplate::class.qualifiedName!!,
+                    { ctx, types -> ScriptArgsWithTypes(arrayOf(ctx.getBindings(ScriptContext.ENGINE_SCOPE)), types ?: emptyArray()) },
+                    arrayOf(Bindings::class))
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

Currently, the tests fail for Java 11, and so does running Kotlin Script language from another project that runs on Java 11. Test failure example:
```
$ JAVA_HOME=/usr/lib/jvm/java-11-openjdk mvn clean package test -Denforcer.skip=true
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.scijava.plugins.scripting.kotlin.KotlinTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.233 s <<< FAILURE! - in org.scijava.plugins.scripting.kotlin.KotlinTest
[ERROR] org.scijava.plugins.scripting.kotlin.KotlinTest  Time elapsed: 2.23 s  <<< ERROR!
java.lang.StackOverflowError

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   KotlinTest.org.scijava.plugins.scripting.kotlin.KotlinTest » StackOverflow
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
```

Upon some inspection with this `@ClassRule`:
```kotlin
class LogExceptionRule : TestRule {
    override fun apply(s: Statement?, d: Description?): Statement {
        return object: Statement() {
            override fun evaluate() {
                try {
                    s!!.evaluate()
                } catch (t: Throwable) {
                    System.err.println("Caught throwable ${t.javaClass.simpleName}: ${t.message}")
                    t.printStackTrace()
                }
            }

        }
    }
}
```
I was able to get the entire stack trace:
```
Caught throwable StackOverflowError: null
java.lang.StackOverflowError
        at java.base/jdk.internal.reflect.Reflection.verifyMemberAccess(Reflection.java:132)
        at java.base/java.util.ServiceLoader.checkCaller(ServiceLoader.java:568)
        at java.base/java.util.ServiceLoader.<init>(ServiceLoader.java:504)
        at java.base/java.util.ServiceLoader.load(ServiceLoader.java:1647)
        at java.scripting/javax.script.ScriptEngineManager.getServiceLoader(ScriptEngineManager.java:92)
        at java.scripting/javax.script.ScriptEngineManager$1.run(ScriptEngineManager.java:105)
        at java.scripting/javax.script.ScriptEngineManager$1.run(ScriptEngineManager.java:102)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.scripting/javax.script.ScriptEngineManager.initEngines(ScriptEngineManager.java:101)
        at java.scripting/javax.script.ScriptEngineManager.init(ScriptEngineManager.java:87)
        at java.scripting/javax.script.ScriptEngineManager.<init>(ScriptEngineManager.java:62)
        at org.scijava.plugins.scripting.kotlin.KotlinScriptLanguage$Factory.getScriptEngine(KotlinScriptLanguage.kt:56)
        at org.scijava.script.AdaptedScriptLanguage.getScriptEngine(AdaptedScriptLanguage.java:137)
        at java.scripting/javax.script.ScriptEngineManager.getEngineByExtension(ScriptEngineManager.java:291)
        at org.scijava.plugins.scripting.kotlin.KotlinScriptLanguage$Factory.getScriptEngine(KotlinScriptLanguage.kt:56)
        at org.scijava.script.AdaptedScriptLanguage.getScriptEngine(AdaptedScriptLanguage.java:137)
        at java.scripting/javax.script.ScriptEngineManager.getEngineByExtension(ScriptEngineManager.java:291)
        at ...
```
`KotlinScriptLanguage$Factory.getScriptEngine` is called recursively through `ScriptEngineManager.getEngineByExtension`. It is unclear to me, why this happens (or why it worked at all before with Java 8). A change from Java 8 to Java 11 how `javax.script.ScriptEngineFactory`s are detected may be a plausible explanation.

This PR calls
```kotlin
KotlinJsr223DefaultScriptEngineFactory().scriptEngine
```
directly instead of going through `ScriptEngineManager.getEngineByExtension`. 

Fixes #5 if upstream `scijava-maven-plugin` is updated to include `notOptionalFilter` in `PopulateAppMojo`