### PR TITLE
Fix circular dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,12 +137,6 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>scijava-common</artifactId>
-			<classifier>tests</classifier>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,6 @@ Wisconsin-Madison.</license.copyrightOwners>
 										<includes>
 											<include>org.jetbrains.intellij.deps:trove4j</include>
 											<include>org.jetbrains.kotlin:kotlin-compiler-embeddable</include>
-											<include>org.jetbrains.kotlin:kotlin-script-runtime</include>
 											<include>org.jetbrains.kotlin:kotlin-reflect</include>
 											<include>org.jetbrains.kotlin:kotlin-daemon-embeddable</include>
 										</includes>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
 
-		<kotlin-compiler-embeddable.optional>false</kotlin-compiler-embeddable.optional>
+		<shaded-jars.optional>false</shaded-jars.optional>
 		<scijava-maven-plugin.version>2.1.0</scijava-maven-plugin.version>
 	</properties>
 
@@ -118,7 +118,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-compiler-embeddable</artifactId>
 			<version>${kotlin.version}</version>
-			<optional>${kotlin-compiler-embeddable.optional}</optional>
+			<optional>${shaded-jars.optional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
@@ -129,6 +129,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-scripting-jsr223</artifactId>
 			<version>${kotlin.version}</version>
+			<optional>${shaded-jars.optional}</optional>
 		</dependency>
 
 		<!-- Test dependencies -->
@@ -150,7 +151,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 				</property>
 			</activation>
 			<properties>
-				<kotlin-compiler-embeddable.optional>true</kotlin-compiler-embeddable.optional>
+				<shaded-jars.optional>true</shaded-jars.optional>
 				<scijava.ignoreOptionalDependencies>true</scijava.ignoreOptionalDependencies>
 			</properties>
 			<build>
@@ -172,6 +173,14 @@ Wisconsin-Madison.</license.copyrightOwners>
 											<include>org.jetbrains.kotlin:kotlin-compiler-embeddable</include>
 											<include>org.jetbrains.kotlin:kotlin-reflect</include>
 											<include>org.jetbrains.kotlin:kotlin-daemon-embeddable</include>
+											<include>org.jetbrains.kotlin:kotlin-script-runtime</include>
+											<include>org.jetbrains.kotlin:kotlin-scripting-jsr223</include>
+											<include>org.jetbrains.kotlin:kotlin-scripting-common</include>
+											<include>org.jetbrains.kotlinx:kotlinx-coroutines-core</include>
+											<include>org.jetbrains.kotlin:kotlin-scripting-jvm</include>
+											<include>org.jetbrains.kotlin:kotlin-scripting-jvm-host</include>
+											<include>org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable</include>
+											<include>org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable</include>
 										</includes>
 									</artifactSet>
 									<relocations>

--- a/src/test/kotlin/org/scijava/plugins/scripting/kotlin/KotlinTest.kt
+++ b/src/test/kotlin/org/scijava/plugins/scripting/kotlin/KotlinTest.kt
@@ -33,15 +33,16 @@ import org.junit.Assert
 import org.junit.BeforeClass
 import org.junit.Test
 import org.scijava.Context
-import org.scijava.script.AbstractScriptLanguageTest
 import org.scijava.script.ScriptLanguage
 import org.scijava.script.ScriptService
 import java.io.IOException
 import java.util.concurrent.ExecutionException
 import javax.script.ScriptContext
 import javax.script.ScriptEngine
+import javax.script.ScriptEngineManager
 import javax.script.ScriptException
 import kotlin.math.E
+
 
 /**
  * Kotlin unit tests.
@@ -49,10 +50,10 @@ import kotlin.math.E
  * @author Curtis Rueden
  * @author Philipp Hanslovsky
  */
-class KotlinTest : AbstractScriptLanguageTest() {
+class KotlinTest {
 
     @Test
-    fun testDiscovery() = assertDiscovered(KotlinScriptLanguage::class.java)
+    fun testDiscovery() = KotlinScriptLanguage::class.java.assertDiscovered()
 
     @Test
     @Throws(InterruptedException::class, ExecutionException::class, IOException::class, ScriptException::class)
@@ -90,4 +91,11 @@ class KotlinTest : AbstractScriptLanguageTest() {
         private lateinit var _engine: ScriptEngine
         val engine get() = _engine
     }
+}
+
+fun Class<out ScriptLanguage?>.assertDiscovered() {
+    ScriptEngineManager()
+        .engineFactories
+        .firstOrNull { isInstance(it) }
+        ?: Assert.fail("$name not discovered by JSR-223 framework")
 }


### PR DESCRIPTION
The Fiji updater reports circular dependencies when trying to upload to `ntakt` updae site. Thanks to help from @ctrueden I was able to identify duplicate classes that appear both in the shaded `scripting-kotlin` jar and the `org.jetbrains.kotlin:kotlin-script-runtime:jar:1.4.30:runtime` transitive dependency. The `org.jetbrains.kotlin:kotlin-compiler-embeddable:jar:1.4.30:compile` dependency that pulls in this transitive dependency is marked as optional. No other dependency has `kotlin-script-runtime` as dependency so I am a bit confused about why `kotlin-script-runtime` is installed in the first place. Removing it from the shaded jar solved the issue of duplicate classes. I have yet to confirm that the Fiji updater does not report any circular dependencies after this fix.

For reference, [discussion on gitter](https://gitter.im/imagej/imagej?at=606fae56d79539186147fc9d)

![](https://files.gitter.im/5503522515522ed4b3dd3b5a/vXBI/Screenshot_20210408_223150.png)

For completeness, this is the Maven dependency tree:
```
org.scijava:scripting-kotlin:jar:0.1.2-SNAPSHOT
+- org.scijava:scijava-common:jar:2.83.3:compile
|  +- org.scijava:parsington:jar:2.0.0:compile
|  \- org.bushe:eventbus:jar:1.4:compile
+- org.jetbrains.kotlin:kotlin-compiler-embeddable:jar:1.4.30:compile
|  +- org.jetbrains.kotlin:kotlin-script-runtime:jar:1.4.30:runtime
|  +- org.jetbrains.kotlin:kotlin-reflect:jar:1.4.30:runtime
|  +- org.jetbrains.kotlin:kotlin-daemon-embeddable:jar:1.4.30:runtime
|  \- org.jetbrains.intellij.deps:trove4j:jar:1.0.20181211:runtime
+- org.jetbrains.kotlin:kotlin-stdlib:jar:1.4.30:compile
|  +- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.4.30:compile
|  \- org.jetbrains:annotations:jar:13.0:compile
+- org.jetbrains.kotlin:kotlin-scripting-jsr223:jar:1.4.30:compile
|  +- org.jetbrains.kotlin:kotlin-scripting-common:jar:1.4.30:runtime
|  |  \- org.jetbrains.kotlinx:kotlinx-coroutines-core:jar:1.3.8:runtime
|  +- org.jetbrains.kotlin:kotlin-scripting-jvm:jar:1.4.30:runtime
|  +- org.jetbrains.kotlin:kotlin-scripting-jvm-host:jar:1.4.30:runtime
|  \- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:jar:1.4.30:runtime
|     \- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:jar:1.4.30:runtime
+- junit:junit:jar:4.13:test
|  \- org.hamcrest:hamcrest-core:jar:1.3:test
\- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.4.30:compile
   \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.4.30:compile
```

## Solution
I found out that `org.jetbrains.kotlin:kotlin-scripting-jsr223:jar` has `kotlin-compiler-embeddable` as a transitive dependency with scope `runtime`. For some reason, this transitive dependency would only show in `mvn dependency:tree` when I did not have `kotlin-compiler-embeddable` as dependency for `scripting-kotlin`. In the end, the solution was to simply include `kotlin-scripting-jsr233` and its transitive dependencies in the shaded jar. I tested this branch in a clean `Fiji.app` and distributed/ to/installed from the [`ntakt` update site](https://sites.imagej.net/ntakt/).
