### PR TITLE
Bump Kotlin and scijava POM

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up CI environment

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up CI environment

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,8 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<kotlin-compiler-embeddable.optional>false</kotlin-compiler-embeddable.optional>
 		<!-- NB: kotlin requires 1.X for versions up to 8. This can be removed when scijava.jvm.version goes to 9 -->
 		<kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+
+		<kotlin.version>1.7.20</kotlin.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>36.0.0</version>
+		<version>37.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -94,9 +94,9 @@ Wisconsin-Madison.</license.copyrightOwners>
 
 		<kotlin-compiler-embeddable.optional>false</kotlin-compiler-embeddable.optional>
 		<!-- NB: kotlin requires 1.X for versions up to 8. This can be removed when scijava.jvm.version goes to 9 -->
-		<kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+		<kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
 
-		<kotlin.version>1.7.20</kotlin.version>
+		<kotlin.version>1.9.23</kotlin.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
This PR:
* bumps Kotlin to 1.9.23
* bumps the scijava parent POM to 37.0.0
* sets the JVM target to 11